### PR TITLE
Improve PHPUnit fixture methods

### DIFF
--- a/tests/AsyncMessageQueueManagerTest.php
+++ b/tests/AsyncMessageQueueManagerTest.php
@@ -33,7 +33,7 @@ class AsyncMessageQueueManagerTest extends \AsyncConnection\TestCase
 	/** @var \Psr\Log\LoggerInterface */
 	private $logger;
 
-	public function setUp(): void
+	protected function setUp(): void
 	{
 		$this->logger = $this->getLogger();
 		$this->connectionManagerMock = $this->createMock(AsyncConnectionManager::class);

--- a/tests/Smtp/AsyncSmtpMessageSenderTest.php
+++ b/tests/Smtp/AsyncSmtpMessageSenderTest.php
@@ -18,7 +18,7 @@ class AsyncSmtpMessageSenderTest extends \AsyncConnection\TestCase
 	/** @var string[] */
 	private $recipients = [];
 
-	public function setUp(): void
+	protected function setUp(): void
 	{
 		/** @var \AsyncConnection\Smtp\AsyncSmtpConnectionWriter|\PHPUnit_Framework_MockObject_MockObject $writerMock */
 		$writerMock = $this->createMock(AsyncSmtpConnectionWriter::class);


### PR DESCRIPTION
# Changed log
- According to the [PHPUnit fixture reference](https://phpunit.readthedocs.io/en/7.2/fixtures.html?highlight=fixtures), it seems that the `setUp` method should be `protected`, not `public`.